### PR TITLE
feat: Allow multiple images for products

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -873,6 +873,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -1844,6 +1845,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.14.0",
         "@prisma/engines": "6.14.0"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,7 +64,7 @@ model Producto {
   proveedorId Int
   proveedor   Proveedor    @relation(fields: [proveedorId], references: [id])
   categoria   String
-  imagenUrl   String?
+  imagenUrl   String[]
   activo      Boolean      @default(true)
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt

--- a/src/controllers/product.controller.js
+++ b/src/controllers/product.controller.js
@@ -81,6 +81,11 @@ async function create(req, res) {
       return res.status(400).json({ error: "nombre, precio y categoria son requeridos" });
     }
 
+    // Validar que imagenUrl sea un array con máximo 5 elementos
+    if (imagenUrl && (!Array.isArray(imagenUrl) || imagenUrl.length > 5)) {
+      return res.status(400).json({ error: "imagenUrl debe ser un array con máximo 5 elementos" });
+    }
+
     const producto = await prisma.producto.create({
       data: {
         nombre,
@@ -151,6 +156,11 @@ async function update(req, res) {
 
     if (!proveedor || producto.proveedorId !== proveedor.id) {
       return res.status(403).json({ error: "No tienes permiso para modificar este producto" });
+    }
+
+    // Validar que imagenUrl sea un array con máximo 5 elementos
+    if (imagenUrl && (!Array.isArray(imagenUrl) || imagenUrl.length > 5)) {
+      return res.status(400).json({ error: "imagenUrl debe ser un array con máximo 5 elementos" });
     }
 
     const productoActualizado = await prisma.producto.update({


### PR DESCRIPTION
- Updated `prisma/schema.prisma` to change `imagenUrl` to a `String[]`.
- Added validation to `src/controllers/product.controller.js` to ensure `imagenUrl` is an array with a maximum of 5 elements.